### PR TITLE
refactor: update RoutNet installer and service integration

### DIFF
--- a/routnet.sh
+++ b/routnet.sh
@@ -1,328 +1,390 @@
 #!/usr/bin/env bash
-# -------------------------------------------------------------
-# routnet – Create hotspot on same card without disrupting NetworkManager
-# Author: Meshack Bahati Ouma  
-# -------------------------------------------------------------
+#
+# routnet - Self-contained Wi-Fi hotspot script
+# Author: Meshack Bahati Ouma
+#
+# Purpose:
+#  - Create a Wi-Fi Access Point (AP) while keeping an existing internet connection.
+#  - Try NetworkManager's nmcli hotspot first (clean), fall back to hostapd + dnsmasq.
+#  - Auto-detect interfaces; allow user overrides.
+#  - Provide niceties: debug mode, hacker-style colors, graceful cleanup.
+#
+# Notes:
+#  - Requires kernel/driver support for AP mode (and multi-interface if using same card).
+#  - Run as root (sudo).
+#  - Script is intentionally verbose and friendly — comments explain choices.
+
 set -euo pipefail
+IFS=$'\n\t'
 
-PROGNAME=$(basename "$0")
+# -------------------------
+# Default configuration
+# -------------------------
+AP_SSID="Routnet_AP"
+AP_PASS="routnet123"        # must be >=8 chars
+AP_CHANNEL="6"
+AP_IP="192.168.50.1/24"
+AP_DNS="8.8.8.8"
 
-usage() { cat <<EOF
-Usage: $PROGNAME [options]
+# Empty means auto-detect
+USER_AP_IFACE=""
+USER_WAN_IFACE=""
 
-Create a Wi-Fi AP using the same card that's connected to internet via NetworkManager
-Without disrupting the existing connection or NetworkManager control.
+# Behavior flags
+USE_NMCLI="auto"   # "auto", "yes", "no"
+DEBUG=0
+QUIET=0
 
-OPTIONS
-  -a AP_IF        Virtual AP interface name (default: ap0)
-  -s STA_IF       Client/STA interface with Internet (auto-detected if not given)
-  -S SSID         AP SSID (default: ROUTNET)
-  -P PASS         WPA2 passphrase (omit for open)
-  --driver        hostapd driver (default: nl80211)
-  --dry-run       Print commands instead of running them
-  -h|--help       Show this help
+# Colors - "hacker" green theme
+CSI="\033["
+COL_RESET="${CSI}0m"
+COL_GREEN="${CSI}32m"
+COL_BGREEN="${CSI}92m"
+COL_CYAN="${CSI}36m"
+COL_YELLOW="${CSI}33m"
+COL_RED="${CSI}31m"
 
-EXAMPLES
-  sudo $PROGNAME
-  sudo $PROGNAME -a ap0 -s wlp2s0 -S MyHotspot -P StrongPass
+# -------------------------
+# Helper output functions
+# -------------------------
+cecho(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_BGREEN" "[routnet] $*" "$COL_RESET"; }
+log(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_GREEN" "[routnet] $*" "$COL_RESET"; }
+dbg(){ [[ $DEBUG -eq 1 ]] && printf "%b%s%b\n" "$COL_CYAN" "[routnet-debug] $*" "$COL_RESET"; }
+warn(){ printf "%b%s%b\n" "$COL_YELLOW" "[routnet-warn] $*" "$COL_RESET"; }
+err(){ printf "%b%s%b\n" "$COL_RED" "[routnet-error] $*" "$COL_RESET" >&2; }
 
-NOTES
-  Requires STA+AP capable driver.
-  Works alongside NetworkManager without disrupting existing connections.
+# -------------------------
+# Usage
+# -------------------------
+usage() {
+  cat <<EOF
+$(printf "%b" "$COL_BGREEN")routnet$(printf "%b" "$COL_RESET") - create a hotspot while keeping internet
+
+Usage: sudo routnet [options]
+
+Options:
+  --iface <iface>      Use this wireless interface (AP) instead of auto-detect
+  --wan <iface>        Override WAN (internet) interface
+  --ap-ip <CIDR>       AP interface IP (default: $AP_IP)
+  --ap-dns <IP>        DNS to give clients (default: $AP_DNS)
+  --ap-ssid <SSID>     AP SSID (default: $AP_SSID)
+  --ap-pass <pass>     WPA2 passphrase (min 8 chars)
+  --ap-channel <ch>    Wi-Fi channel (default: $AP_CHANNEL)
+  --nmcli-yes          Force using NetworkManager (nmcli) hotspot mode
+  --nmcli-no           Force NOT using nmcli (use manual hostapd)
+  --debug              Enable debug (prints extra messages)
+  --quiet              Minimal output
+  -h, --help           Show this help
 EOF
 }
 
-# ---- defaults ------------------------------------------------
-AP_IF=ap0
-STA_IF=""
-SSID="ROUTNET"
-PASS=""
-DRIVER="nl80211"
-DRY_RUN=0
-
-# Initialize variables to prevent unbound errors
-HOSTAPD_CONF=""
-DNSMASQ_CONF=""
-CONNECTION_SSID=""
-CONNECTION_PSK=""
-NM_MANAGED=false
-
-# ---- arg parser ----------------------------------------------
+# -------------------------
+# Parse args
+# -------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -a)      AP_IF=$2; shift 2 ;;
-    -s)      STA_IF=$2; shift 2 ;;
-    -S)      SSID=$2;  shift 2 ;;
-    -P)      PASS=$2;  shift 2 ;;
-    --driver) DRIVER=$2; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
+    --iface) USER_AP_IFACE="$2"; shift 2 ;;
+    --wan) USER_WAN_IFACE="$2"; shift 2 ;;
+    --ap-ip) AP_IP="$2"; shift 2 ;;
+    --ap-dns) AP_DNS="$2"; shift 2 ;;
+    --ap-ssid) AP_SSID="$2"; shift 2 ;;
+    --ap-pass) AP_PASS="$2"; shift 2 ;;
+    --ap-channel) AP_CHANNEL="$2"; shift 2 ;;
+    --nmcli-yes) USE_NMCLI="yes"; shift ;;
+    --nmcli-no) USE_NMCLI="no"; shift ;;
+    --debug) DEBUG=1; shift ;;
+    --quiet) QUIET=1; shift ;;
     -h|--help) usage; exit 0 ;;
-    *) echo "Unknown arg: $1"; usage; exit 2 ;;
+    *) err "Unknown option: $1"; usage; exit 1 ;;
   esac
 done
 
-# ---- helpers -------------------------------------------------
-run() {
-  [[ $DRY_RUN -eq 1 ]] && echo "+ $*" && return
-  "$@"
-}
+# -------------------------
+# Basic checks
+# -------------------------
+command -v iw >/dev/null 2>&1 || { err "This script requires 'iw' (install package 'iw')."; exit 1; }
+command -v ip >/dev/null 2>&1 || { err "This script requires iproute2 (ip)."; exit 1; }
+HAS_NMCLI=0; command -v nmcli >/dev/null 2>&1 && HAS_NMCLI=1
+HAS_HOSTAPD=0; command -v hostapd >/dev/null 2>&1 && HAS_HOSTAPD=1
+HAS_DNSMASQ=0; command -v dnsmasq >/dev/null 2>&1 && HAS_DNSMASQ=1
+HAS_NFT=0; command -v nft >/dev/null 2>&1 && HAS_NFT=1
+HAS_IPTABLES=0; command -v iptables >/dev/null 2>&1 && HAS_IPTABLES=1
 
-die() { echo "[ERROR] $*" >&2; exit 1; }
-info() { echo "[INFO] $*"; }
-warn() { echo "[WARN] $*" >&2; }
-
-# ---- root check ---------------------------------------------
-[[ $EUID -eq 0 ]] || die "Run with sudo."
-
-# ---- detect STA interface -----------------------------------
-detect_sta() {
-  local dev=""
-  # Prefer NetworkManager for detection since we want to work with it
-  if command -v nmcli &>/dev/null; then
-    dev=$(nmcli -t -f DEVICE,TYPE,STATE dev | awk -F: '$2=="wifi" && $3=="connected"{print $1; exit}')
-    [[ -n $dev ]] && { echo "$dev"; return; }
-  fi
-  # Fallback to iw if NetworkManager not available
-  for dev in $(iw dev | awk '$1=="Interface"{print $2}'); do
-    iw dev "$dev" link 2>/dev/null | grep -q 'SSID:' && { echo "$dev"; return; }
-  done
-  return 1
-}
-
-[[ -n $STA_IF ]] || STA_IF=$(detect_sta) \
-  || die "No connected STA interface detected. Specify with -s."
-
-ip link show "$STA_IF" &>/dev/null || die "STA interface $STA_IF does not exist."
-
-# ---- Check if interface is managed by NetworkManager --------
-is_nm_managed() {
-  local iface="${1:-$STA_IF}"
-  if command -v nmcli &>/dev/null; then
-    # Try different methods to check if interface is managed
-    # Method 1: Check general device status
-    if nmcli -t -f DEVICE dev | grep -q "^$iface$"; then
-        # Method 2: Check if device is currently managed by looking at connection state
-        local state=$(nmcli -t -f DEVICE,STATE dev | grep "^$iface:" | cut -d: -f2)
-        if [[ "$state" == "connected" || "$state" == "connecting" || "$state" == "disconnected" ]]; then
-            return 0  # Managed by NetworkManager
-        fi
-    fi
-    # Method 3: Check using device show (more reliable)
-    if nmcli device show "$iface" &>/dev/null; then
-        return 0
-    fi
-  fi
-  return 1  # Not managed by NetworkManager
-}
-
-# ---- STA+AP capability check --------------------------------
-supports_concurrency() {
-  local phy
-  phy=$(iw dev "$STA_IF" info | awk '$1=="wiphy"{print "phy"$2}')
-  [[ -n $phy ]] || return 1
-  iw phy "$phy" info | awk '/valid interface combinations/{f=1} f && /managed.*AP/ {print; exit}' | grep -q managed
-}
-supports_concurrency || die "Driver for $STA_IF does not report STA+AP concurrency."
-
-# ---- Connection Management ----------------------------------
-save_wifi_connection() {
-    if command -v nmcli &>/dev/null; then
-        CONNECTION_SSID=$(nmcli -t -f NAME,DEVICE con show --active | grep "$STA_IF" | cut -d: -f1 | head -1)
-        if [[ -n "$CONNECTION_SSID" ]]; then
-            CONNECTION_PSK=$(nmcli -s -g 802-11-wireless-security.psk connection show "$CONNECTION_SSID" 2>/dev/null || echo "")
-            info "Saved connection details for $CONNECTION_SSID"
-        fi
-    fi
-}
-
-setup_manual_connection() {
-    if [[ -n "$CONNECTION_SSID" && -n "$CONNECTION_PSK" ]]; then
-        info "Setting up manual connection to $CONNECTION_SSID"
-        run pkill -f "wpa_supplicant.*$STA_IF" 2>/dev/null || true
-        run wpa_supplicant -B -i "$STA_IF" -c <(wpa_passphrase "$CONNECTION_SSID" "$CONNECTION_PSK")
-        run dhclient "$STA_IF" 2>/dev/null || warn "DHCP client may have issues"
-    else
-        warn "Could not setup manual connection, using current network configuration"
-    fi
-}
-
-# ---- Conflict Handling --------------------------------------
-find_available_ap_interface() {
-    local base_name="${1:-ap}"
-    local candidate="${base_name}0"
-    local counter=0
-    
-    # Check if base name is available
-    if ! ip link show "$candidate" &>/dev/null; then
-        echo "$candidate"
-        return 0
-    fi
-    
-    # Find next available number
-    while ip link show "${base_name}${counter}" &>/dev/null; do
-        ((counter++))
-        if [[ $counter -gt 10 ]]; then
-            echo "hotspot${RANDOM:0:3}"
-            return 0
-        fi
-    done
-    
-    echo "${base_name}${counter}"
-}
-
-# ---- Cleanup function ---------------------------------------
-cleanup() {
-    info "Cleaning up..."
-    
-    # Kill our background processes
-    pkill -f "hostapd.*/tmp/routnet" 2>/dev/null || true
-    pkill -f "dnsmasq.*/tmp/routnet" 2>/dev/null || true
-    pkill -f "wpa_supplicant.*$STA_IF" 2>/dev/null || true
-    pkill -f "dhclient.*$STA_IF" 2>/dev/null || true
-    
-    # Remove iptables rules we added
-    iptables -t nat -D POSTROUTING -o "$STA_IF" -j MASQUERADE 2>/dev/null || true
-    iptables -D FORWARD -i "$STA_IF" -o "$AP_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
-    iptables -D FORWARD -i "$AP_IF" -o "$STA_IF" -j ACCEPT 2>/dev/null || true
-    
-    # Remove virtual interface if we created it
-    if ip link show "$AP_IF" &>/dev/null; then
-        run iw dev "$AP_IF" del 2>/dev/null || true
-    fi
-    
-    # Restore NetworkManager if we disabled it
-    if [[ "$NM_MANAGED" == "true" ]]; then
-        info "Restoring NetworkManager management for $STA_IF"
-        run nmcli device set "$STA_IF" managed yes 2>/dev/null || true
-        run nmcli device connect "$STA_IF" 2>/dev/null || true
-    fi
-    
-    # Remove temp files
-    rm -f "${HOSTAPD_CONF}" "${DNSMASQ_CONF}" 2>/dev/null || true
-    
-    info "Cleanup complete"
-    exit 0
-}
-
-trap cleanup INT TERM EXIT
-
-# ---- Check for existing processes using the interface ----
-info "Checking for existing processes using $STA_IF"
-run pkill -f "hostapd.*$STA_IF" 2>/dev/null || true
-run pkill -f "wpa_supplicant.*$STA_IF" 2>/dev/null || true
-
-# Remove any existing virtual interfaces that might conflict
-for iface in $(iw dev | awk '/Interface/{print $2}' | grep -E '^(ap|hotspot)[0-9]*$'); do
-    warn "Removing existing virtual interface: $iface"
-    run iw dev "$iface" del 2>/dev/null || true
-done
-
-sleep 1
-
-# ---- Main Execution -----------------------------------------
-
-# Check if NetworkManager is managing the interface
-if is_nm_managed "$STA_IF"; then
-    info "NetworkManager is managing $STA_IF - preparing for hotspot"
-    save_wifi_connection
-    info "Temporarily disabling NetworkManager management"
-    run nmcli device set "$STA_IF" managed no 2>/dev/null || warn "Could not disable NetworkManager management"
-    NM_MANAGED=true
-    setup_manual_connection
+if [[ "$USE_NMCLI" == "auto" ]]; then
+  [[ $HAS_NMCLI -eq 1 ]] && NMCLI_USABLE=1 || NMCLI_USABLE=0
 else
-    info "NetworkManager not managing $STA_IF - using current connection"
-    NM_MANAGED=false
+  [[ "$USE_NMCLI" == "yes" ]] && NMCLI_USABLE=1 || NMCLI_USABLE=0
 fi
 
-# Handle interface conflicts
-if ip link show "$AP_IF" &>/dev/null; then
-    warn "Interface $AP_IF already exists - finding available name"
-    AP_IF=$(find_available_ap_interface "ap")
-    info "Using available interface: $AP_IF"
+# Validate passphrase length (only when provided)
+if [[ -n "$AP_PASS" && ${#AP_PASS} -lt 8 ]]; then
+  err "AP passphrase must be at least 8 characters."
+  exit 1
 fi
 
-# Remove any existing conflicting interface
-if ip link show "$AP_IF" &>/dev/null; then
-    warn "Removing conflicting interface $AP_IF"
-    run iw dev "$AP_IF" del 2>/dev/null || true
-    sleep 1
+# -------------------------
+# Cleanup handling
+# -------------------------
+TEMP_DIR=""
+CLEANUP_CMDS=()
+cleanup() {
+  log "Cleaning up..."
+  # run cleanup commands in reverse order
+  for ((i=${#CLEANUP_CMDS[@]}-1; i>=0; i--)); do
+    dbg "cleanup: ${CLEANUP_CMDS[i]}"
+    eval "${CLEANUP_CMDS[i]}" || true
+  done
+  [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+  log "Done."
+}
+trap cleanup EXIT INT TERM
+
+# -------------------------
+# Interface detection
+# Steps:
+# 1) If user gave --iface, use it (AP interface)
+# 2) Detect default WAN via `ip route get 8.8.8.8`
+# 3) List wireless interfaces via `iw dev`
+# 4) Prefer a wireless iface that is not WAN (free)
+# 5) If only single wireless iface present and it's WAN, we'll attempt STA+AP mode
+# -------------------------
+AP_BASE_IFACE=""
+WAN_IFACE=""
+
+if [[ -n "$USER_AP_IFACE" ]]; then
+  AP_BASE_IFACE="$USER_AP_IFACE"
+  log "Using user-specified AP interface: $AP_BASE_IFACE"
 fi
 
-# Create virtual AP interface
-info "Creating virtual AP interface $AP_IF on $STA_IF"
-run iw dev "$STA_IF" interface add "$AP_IF" type __ap
-sleep 2
-run ip link set "$AP_IF" up
-info "AP interface $AP_IF is ready"
+# Detect default WAN iface if not user-specified
+if [[ -n "$USER_WAN_IFACE" ]]; then
+  WAN_IFACE="$USER_WAN_IFACE"
+  log "Using user-specified WAN: $WAN_IFACE"
+else
+  dbg "Detecting default route (internet) interface..."
+  # ip route get 8.8.8.8 is more robust than parsing "default" line
+  DEFAULT_ROUTE=$(ip route get 8.8.8.8 2>/dev/null || true)
+  if [[ -n "$DEFAULT_ROUTE" ]]; then
+    WAN_IFACE=$(echo "$DEFAULT_ROUTE" | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
+    dbg "Detected WAN interface: $WAN_IFACE"
+  else
+    dbg "Could not detect WAN via ip route."
+  fi
+fi
 
-# Configure hostapd
-info "Setting up hotspot '$SSID' on $AP_IF"
+# If AP iface not provided, pick one
+if [[ -z "$AP_BASE_IFACE" ]]; then
+  dbg "Listing wireless interfaces..."
+  WIFI_IFACES=$(iw dev | awk '$1=="Interface"{print $2}')
+  dbg "Wireless ifaces: $WIFI_IFACES"
+  for iface in $WIFI_IFACES; do
+    if [[ -n "$WAN_IFACE" && "$iface" == "$WAN_IFACE" ]]; then
+      dbg "Skipping $iface because it is the WAN interface"
+      continue
+    fi
+    AP_BASE_IFACE="$iface"
+    break
+  done
 
-# Kill any previous hostapd instances
-pkill -f "hostapd.*$AP_IF" 2>/dev/null || true
+  # If none chosen yet and WAN is wireless, pick it (single card case)
+  if [[ -z "$AP_BASE_IFACE" && -n "$WAN_IFACE" ]]; then
+    for iface in $WIFI_IFACES; do
+      if [[ "$iface" == "$WAN_IFACE" ]]; then
+        AP_BASE_IFACE="$iface"
+        log "Only single wireless interface found; will attempt STA+AP on $AP_BASE_IFACE"
+        break
+      fi
+    done
+  fi
 
-HOSTAPD_CONF=$(mktemp /tmp/routnet-hostapd-XXXXXX.conf)
-cat >"$HOSTAPD_CONF" <<EOF
+  if [[ -z "$AP_BASE_IFACE" ]]; then
+    err "No wireless interface detected. Provide one with --iface."
+    exit 1
+  fi
+fi
+
+dbg "AP base interface chosen: $AP_BASE_IFACE"
+dbg "WAN interface chosen: ${WAN_IFACE:-<none>}"
+
+# -------------------------
+# Verify driver supports AP mode
+# -------------------------
+if ! iw list | grep -A 10 "Supported interface modes" | grep -q "AP"; then
+  err "Wireless driver does not advertise AP support. Cannot continue."
+  exit 1
+fi
+
+# -------------------------
+# Try NetworkManager nmcli hotspot if available & desired
+# -------------------------
+if [[ $NMCLI_USABLE -eq 1 ]]; then
+  log "Attempting NetworkManager (nmcli) hotspot on $AP_BASE_IFACE"
+  # Attempt to create hotspot; some nmcli versions manage DHCP/NAT automatically
+  if nmcli device wifi hotspot ifname "$AP_BASE_IFACE" ssid "$AP_SSID" password "$AP_PASS" >/dev/null 2>&1; then
+    log "nmcli hotspot created and is managed by NetworkManager."
+    log "Use 'nmcli connection show' to inspect, and 'nmcli connection down Hotspot' to bring it down."
+    exit 0
+  else
+    warn "nmcli hotspot failed or driver does not support simultaneous AP+STA. Falling back to manual hostapd."
+  fi
+fi
+
+# -------------------------
+# Manual method: create a virtual AP interface from AP_BASE_IFACE,
+# prepare hostapd+dnsmasq configs in a temp dir, configure NAT.
+# -------------------------
+AP_IF="${AP_BASE_IFACE}_ap"
+# if AP_IF exists, try numbered alternatives
+if ip link show "$AP_IF" >/dev/null 2>&1; then
+  for i in {1..9}; do
+    candidate="${AP_BASE_IFACE}_ap${i}"
+    if ! ip link show "$candidate" >/dev/null 2>&1; then
+      AP_IF="$candidate"
+      break
+    fi
+  done
+fi
+
+dbg "Will attempt to create AP virtual interface: $AP_IF"
+
+# Try to create virtual AP interface. If it fails, advise user.
+if ! iw dev "$AP_BASE_IFACE" interface add "$AP_IF" type __ap >/dev/null 2>&1; then
+  err "Failed to create virtual AP interface $AP_IF. Driver may not support multi-interface or NetworkManager is blocking it."
+  err "If NetworkManager is running, consider: 'nmcli device set <iface> managed no' for the generated AP interface, or use a second USB Wi-Fi adapter."
+  exit 1
+fi
+CLEANUP_CMDS+=("ip link delete $AP_IF || true")
+
+# Bring AP iface up
+ip link set "$AP_IF" up
+
+# Create temporary directory for configs & logs
+TEMP_DIR=$(mktemp -d -t routnet-XXXX)
+CLEANUP_CMDS+=("rm -rf '$TEMP_DIR' || true")
+HOSTAPD_CONF="$TEMP_DIR/hostapd.conf"
+DNSMASQ_CONF="$TEMP_DIR/dnsmasq.conf"
+HOSTAPD_LOG="$TEMP_DIR/hostapd.log"
+DNSMASQ_LOG="$TEMP_DIR/dnsmasq.log"
+
+# Generate hostapd config
+cat > "$HOSTAPD_CONF" <<HOSTAPD
+# hostapd config generated by routnet
 interface=$AP_IF
-driver=$DRIVER
-ssid=$SSID
+driver=nl80211
+ssid=$AP_SSID
 hw_mode=g
-channel=6
+channel=$AP_CHANNEL
+wmm_enabled=1
+macaddr_acl=0
+auth_algs=1
 ignore_broadcast_ssid=0
-country_code=US
-EOF
-
-if [[ -n "$PASS" ]]; then
-    cat >>"$HOSTAPD_CONF" <<EOF
 wpa=2
-wpa_passphrase=$PASS
+wpa_passphrase=$AP_PASS
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
-EOF
-fi
+HOSTAPD
 
-run hostapd -B "$HOSTAPD_CONF"
-info "hostapd started for $AP_IF"
+# Prepare DHCP range based on AP_IP first three octets
+AP_NET_BASE=$(echo "$AP_IP" | cut -d. -f1-3)
+DHCP_START="${AP_NET_BASE}.10"
+DHCP_END="${AP_NET_BASE}.100"
 
-# Configure networking
-run ip addr add 192.168.50.1/24 dev "$AP_IF" 2>/dev/null || \
-    warn "IP address already set on $AP_IF"
-
-run sysctl -w net.ipv4.ip_forward=1 >/dev/null
-
-# Setup iptables rules
-run iptables -t nat -C POSTROUTING -o "$STA_IF" -j MASQUERADE 2>/dev/null \
-    || run iptables -t nat -A POSTROUTING -o "$STA_IF" -j MASQUERADE
-run iptables -C FORWARD -i "$STA_IF" -o "$AP_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
-    || run iptables -A FORWARD -i "$STA_IF" -o "$AP_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT
-run iptables -C FORWARD -i "$AP_IF" -o "$STA_IF" -j ACCEPT 2>/dev/null \
-    || run iptables -A FORWARD -i "$AP_IF" -o "$STA_IF" -j ACCEPT
-
-# Configure DHCP
-if command -v dnsmasq &>/dev/null; then
-    DNSMASQ_CONF=$(mktemp /tmp/routnet-dnsmasq-XXXXXX.conf)
-    cat >"$DNSMASQ_CONF" <<EOF
+# Generate dnsmasq config
+cat > "$DNSMASQ_CONF" <<DNSMASQ
+# dnsmasq config generated by routnet
 interface=$AP_IF
 bind-interfaces
-dhcp-range=192.168.50.10,192.168.50.100,255.255.255.0,12h
-dhcp-option=3,192.168.50.1
-dhcp-option=6,8.8.8.8,8.8.4.4
-EOF
-    run dnsmasq -C "$DNSMASQ_CONF"
-    info "dnsmasq started for DHCP on $AP_IF"
-else
-    warn "dnsmasq not found - no DHCP service"
-    info "Clients need manual IP: 192.168.50.x/24, GW: 192.168.50.1, DNS: 8.8.8.8"
+server=$AP_DNS
+dhcp-range=$DHCP_START,$DHCP_END,12h
+dhcp-option=3,${AP_IP%%/*}   # gateway
+dhcp-option=6,$AP_DNS        # DNS server
+no-resolv
+DNSMASQ
+
+# Assign static IP to AP interface
+AP_ADDR=$(echo "$AP_IP" | cut -d/ -f1)
+ip addr add "$AP_IP" dev "$AP_IF" || true
+CLEANUP_CMDS+=("ip addr flush dev $AP_IF || true")
+
+# Start hostapd
+if [[ $HAS_HOSTAPD -eq 0 ]]; then
+  err "hostapd not installed. Install hostapd or try using --nmcli-yes."
+  exit 1
 fi
 
-info "=== Hotspot Ready ==="
-info "SSID: $SSID"
-[[ -n "$PASS" ]] && info "Password: $PASS"
-info "Interface: $AP_IF (using $STA_IF for internet)"
-info "IP Range: 192.168.50.10-100/24"
-info "Press Ctrl+C to stop hotspot"
+log "Starting hostapd (AP: $AP_IF, SSID: $AP_SSID). Logs: $HOSTAPD_LOG"
+set +e
+hostapd "$HOSTAPD_CONF" >"$HOSTAPD_LOG" 2>&1 &
+HOSTAPD_PID=$!
+set -e
+CLEANUP_CMDS+=("kill $HOSTAPD_PID >/dev/null 2>&1 || true")
 
-# Keep running
-while true; do
-    sleep 3600
-done
+sleep 1
+if ! kill -0 "$HOSTAPD_PID" >/dev/null 2>&1; then
+  err "hostapd failed to start. See $HOSTAPD_LOG"
+  tail -n 50 "$HOSTAPD_LOG" || true
+  exit 1
+fi
+log "hostapd running (pid $HOSTAPD_PID)"
+
+# Start dnsmasq if present
+if [[ $HAS_DNSMASQ -eq 1 ]]; then
+  log "Starting dnsmasq for DHCP (logs: $DNSMASQ_LOG)"
+  dnsmasq --no-resolv --keep-in-foreground --conf-file="$DNSMASQ_CONF" >"$DNSMASQ_LOG" 2>&1 &
+  DNSMASQ_PID=$!
+  CLEANUP_CMDS+=("kill $DNSMASQ_PID >/dev/null 2>&1 || true")
+else
+  warn "dnsmasq not found. Clients may not receive DHCP. You can run dnsmasq or provide static addresses to clients."
+fi
+
+# -------------------------
+# NAT configuration (IP forwarding + masquerade)
+# -------------------------
+log "Configuring IP forwarding and NAT"
+sysctl -w net.ipv4.ip_forward=1 >/dev/null
+CLEANUP_CMDS+=("sysctl -w net.ipv4.ip_forward=0 >/dev/null || true")
+
+# Determine upstream interface for internet sharing (user-provided or previously detected)
+UPSTREAM_IF="${USER_WAN_IFACE:-$WAN_IFACE}"
+
+if [[ -z "$UPSTREAM_IF" ]]; then
+  # pick a non-AP interface which has an IP
+  for ifc in $(ip -o link show | awk -F': ' '{print $2}'); do
+    [[ "$ifc" == "$AP_IF" ]] && continue
+    if ip addr show dev "$ifc" | grep -q "inet "; then
+      UPSTREAM_IF="$ifc"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$UPSTREAM_IF" ]]; then
+  err "Could not determine upstream (WAN) interface. Specify with --wan."
+  exit 1
+fi
+
+log "Using upstream interface: $UPSTREAM_IF"
+
+if [[ $HAS_NFT -eq 1 ]]; then
+  dbg "Applying nftables NAT rule"
+  nft add table ip routnet 2>/dev/null || true
+  nft add chain ip routnet postrouting '{ type nat hook postrouting priority 100; }' 2>/dev/null || true
+  nft add rule ip routnet postrouting oifname "$UPSTREAM_IF" masquerade 2>/dev/null || true
+  CLEANUP_CMDS+=("nft delete table ip routnet >/dev/null 2>&1 || true")
+elif [[ $HAS_IPTABLES -eq 1 ]]; then
+  dbg "Applying iptables NAT rule"
+  iptables -t nat -A POSTROUTING -o "$UPSTREAM_IF" -j MASQUERADE
+  CLEANUP_CMDS+=("iptables -t nat -D POSTROUTING -o \"$UPSTREAM_IF\" -j MASQUERADE || true")
+else
+  err "No nftables or iptables found to setup NAT. Install one or configure NAT manually."
+fi
+
+log "Routnet hotspot should be up now!"
+log "AP iface: $AP_IF"
+log "AP IP: $AP_IP"
+log "SSID: $AP_SSID"
+log "Logs & configs in: $TEMP_DIR"
+log "Press Ctrl-C to stop and cleanup."
+
+# Keep process alive until interrupted
+while true; do sleep 3600; done

--- a/routnet.sh
+++ b/routnet.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 #
 # routnet - Self-contained Wi-Fi hotspot script
-# Author: Meshack Bahati Ouma
+# Author: Meshack Bahati Ouma (updated)
 #
 # Purpose:
-#  - Create a Wi-Fi Access Point (AP) while keeping an existing internet connection.
-#  - Try NetworkManager's nmcli hotspot first (clean), fall back to hostapd + dnsmasq.
-#  - Auto-detect interfaces; allow user overrides.
-#  - Provide niceties: debug mode, hacker-style colors, graceful cleanup.
+#  - Create a Wi-Fi Access Point (AP) while sharing internet
+#  - Works with single or multiple Wi-Fi cards
+#  - Uses nmcli hotspot if available; falls back to hostapd+dnsmasq
+#  - Graceful cleanup and logging
 #
-# Notes:
-#  - Requires kernel/driver support for AP mode (and multi-interface if using same card).
-#  - Run as root (sudo).
-#  - Script is intentionally verbose and friendly — comments explain choices.
-
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -21,21 +16,18 @@ IFS=$'\n\t'
 # Default configuration
 # -------------------------
 AP_SSID="Routnet_AP"
-AP_PASS="routnet123"        # must be >=8 chars
+AP_PASS="routnet123"
 AP_CHANNEL="6"
 AP_IP="192.168.50.1/24"
 AP_DNS="8.8.8.8"
 
-# Empty means auto-detect
 USER_AP_IFACE=""
 USER_WAN_IFACE=""
-
-# Behavior flags
-USE_NMCLI="auto"   # "auto", "yes", "no"
+USE_NMCLI="auto"
 DEBUG=0
 QUIET=0
 
-# Colors - "hacker" green theme
+# Colors
 CSI="\033["
 COL_RESET="${CSI}0m"
 COL_GREEN="${CSI}32m"
@@ -44,37 +36,31 @@ COL_CYAN="${CSI}36m"
 COL_YELLOW="${CSI}33m"
 COL_RED="${CSI}31m"
 
-# -------------------------
-# Helper output functions
-# -------------------------
 cecho(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_BGREEN" "[routnet] $*" "$COL_RESET"; }
 log(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_GREEN" "[routnet] $*" "$COL_RESET"; }
 dbg(){ [[ $DEBUG -eq 1 ]] && printf "%b%s%b\n" "$COL_CYAN" "[routnet-debug] $*" "$COL_RESET"; }
 warn(){ printf "%b%s%b\n" "$COL_YELLOW" "[routnet-warn] $*" "$COL_RESET"; }
 err(){ printf "%b%s%b\n" "$COL_RED" "[routnet-error] $*" "$COL_RESET" >&2; }
 
-# -------------------------
-# Usage
-# -------------------------
 usage() {
   cat <<EOF
-$(printf "%b" "$COL_BGREEN")routnet$(printf "%b" "$COL_RESET") - create a hotspot while keeping internet
+$(printf "%b" "$COL_BGREEN")routnet$(printf "%b" "$COL_RESET") - create a hotspot while sharing internet
 
 Usage: sudo routnet [options]
 
 Options:
-  --iface <iface>      Use this wireless interface (AP) instead of auto-detect
-  --wan <iface>        Override WAN (internet) interface
-  --ap-ip <CIDR>       AP interface IP (default: $AP_IP)
-  --ap-dns <IP>        DNS to give clients (default: $AP_DNS)
+  --iface <iface>      AP interface
+  --wan <iface>        WAN interface
+  --ap-ip <CIDR>       AP IP (default: $AP_IP)
+  --ap-dns <IP>        DNS (default: $AP_DNS)
   --ap-ssid <SSID>     AP SSID (default: $AP_SSID)
   --ap-pass <pass>     WPA2 passphrase (min 8 chars)
   --ap-channel <ch>    Wi-Fi channel (default: $AP_CHANNEL)
-  --nmcli-yes          Force using NetworkManager (nmcli) hotspot mode
-  --nmcli-no           Force NOT using nmcli (use manual hostapd)
-  --debug              Enable debug (prints extra messages)
+  --nmcli-yes          Force using NetworkManager hotspot
+  --nmcli-no           Force NOT using nmcli
+  --debug              Enable debug output
   --quiet              Minimal output
-  -h, --help           Show this help
+  -h, --help           Show help
 EOF
 }
 
@@ -102,8 +88,9 @@ done
 # -------------------------
 # Basic checks
 # -------------------------
-command -v iw >/dev/null 2>&1 || { err "This script requires 'iw' (install package 'iw')."; exit 1; }
-command -v ip >/dev/null 2>&1 || { err "This script requires iproute2 (ip)."; exit 1; }
+command -v iw >/dev/null 2>&1 || { err "Requires 'iw'."; exit 1; }
+command -v ip >/dev/null 2>&1 || { err "Requires iproute2 (ip)."; exit 1; }
+
 HAS_NMCLI=0; command -v nmcli >/dev/null 2>&1 && HAS_NMCLI=1
 HAS_HOSTAPD=0; command -v hostapd >/dev/null 2>&1 && HAS_HOSTAPD=1
 HAS_DNSMASQ=0; command -v dnsmasq >/dev/null 2>&1 && HAS_DNSMASQ=1
@@ -116,11 +103,7 @@ else
   [[ "$USE_NMCLI" == "yes" ]] && NMCLI_USABLE=1 || NMCLI_USABLE=0
 fi
 
-# Validate passphrase length (only when provided)
-if [[ -n "$AP_PASS" && ${#AP_PASS} -lt 8 ]]; then
-  err "AP passphrase must be at least 8 characters."
-  exit 1
-fi
+[[ -n "$AP_PASS" && ${#AP_PASS} -lt 8 ]] && { err "AP passphrase must be ≥8 chars."; exit 1; }
 
 # -------------------------
 # Cleanup handling
@@ -129,7 +112,6 @@ TEMP_DIR=""
 CLEANUP_CMDS=()
 cleanup() {
   log "Cleaning up..."
-  # run cleanup commands in reverse order
   for ((i=${#CLEANUP_CMDS[@]}-1; i>=0; i--)); do
     dbg "cleanup: ${CLEANUP_CMDS[i]}"
     eval "${CLEANUP_CMDS[i]}" || true
@@ -141,124 +123,59 @@ trap cleanup EXIT INT TERM
 
 # -------------------------
 # Interface detection
-# Steps:
-# 1) If user gave --iface, use it (AP interface)
-# 2) Detect default WAN via `ip route get 8.8.8.8`
-# 3) List wireless interfaces via `iw dev`
-# 4) Prefer a wireless iface that is not WAN (free)
-# 5) If only single wireless iface present and it's WAN, we'll attempt STA+AP mode
 # -------------------------
-AP_BASE_IFACE=""
-WAN_IFACE=""
+AP_BASE_IFACE="$USER_AP_IFACE"
+WAN_IFACE="$USER_WAN_IFACE"
 
-if [[ -n "$USER_AP_IFACE" ]]; then
-  AP_BASE_IFACE="$USER_AP_IFACE"
-  log "Using user-specified AP interface: $AP_BASE_IFACE"
-fi
-
-# Detect default WAN iface if not user-specified
-if [[ -n "$USER_WAN_IFACE" ]]; then
-  WAN_IFACE="$USER_WAN_IFACE"
-  log "Using user-specified WAN: $WAN_IFACE"
-else
-  dbg "Detecting default route (internet) interface..."
-  # ip route get 8.8.8.8 is more robust than parsing "default" line
+# Detect WAN if not specified
+if [[ -z "$WAN_IFACE" ]]; then
   DEFAULT_ROUTE=$(ip route get 8.8.8.8 2>/dev/null || true)
   if [[ -n "$DEFAULT_ROUTE" ]]; then
     WAN_IFACE=$(echo "$DEFAULT_ROUTE" | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
-    dbg "Detected WAN interface: $WAN_IFACE"
-  else
-    dbg "Could not detect WAN via ip route."
   fi
 fi
 
-# If AP iface not provided, pick one
+# Auto-select AP iface
 if [[ -z "$AP_BASE_IFACE" ]]; then
-  dbg "Listing wireless interfaces..."
   WIFI_IFACES=$(iw dev | awk '$1=="Interface"{print $2}')
-  dbg "Wireless ifaces: $WIFI_IFACES"
   for iface in $WIFI_IFACES; do
-    if [[ -n "$WAN_IFACE" && "$iface" == "$WAN_IFACE" ]]; then
-      dbg "Skipping $iface because it is the WAN interface"
-      continue
-    fi
-    AP_BASE_IFACE="$iface"
-    break
+    [[ -n "$WAN_IFACE" && "$iface" == "$WAN_IFACE" ]] && continue
+    AP_BASE_IFACE="$iface"; break
   done
-
-  # If none chosen yet and WAN is wireless, pick it (single card case)
-  if [[ -z "$AP_BASE_IFACE" && -n "$WAN_IFACE" ]]; then
-    for iface in $WIFI_IFACES; do
-      if [[ "$iface" == "$WAN_IFACE" ]]; then
-        AP_BASE_IFACE="$iface"
-        log "Only single wireless interface found; will attempt STA+AP on $AP_BASE_IFACE"
-        break
-      fi
-    done
-  fi
-
-  if [[ -z "$AP_BASE_IFACE" ]]; then
-    err "No wireless interface detected. Provide one with --iface."
-    exit 1
-  fi
+  # If only single card, reuse WAN
+  [[ -z "$AP_BASE_IFACE" && -n "$WAN_IFACE" ]] && AP_BASE_IFACE="$WAN_IFACE" && log "Single wireless card; using $AP_BASE_IFACE for STA+AP"
 fi
 
-dbg "AP base interface chosen: $AP_BASE_IFACE"
-dbg "WAN interface chosen: ${WAN_IFACE:-<none>}"
+[[ -z "$AP_BASE_IFACE" ]] && { err "No wireless interface detected."; exit 1; }
+
+dbg "AP iface: $AP_BASE_IFACE, WAN iface: $WAN_IFACE"
 
 # -------------------------
-# Verify driver supports AP mode
-# -------------------------
-if ! iw list | grep -A 10 "Supported interface modes" | grep -q "AP"; then
-  err "Wireless driver does not advertise AP support. Cannot continue."
-  exit 1
-fi
-
-# -------------------------
-# Try NetworkManager nmcli hotspot if available & desired
+# Attempt NMCLI hotspot first
 # -------------------------
 if [[ $NMCLI_USABLE -eq 1 ]]; then
-  log "Attempting NetworkManager (nmcli) hotspot on $AP_BASE_IFACE"
-  # Attempt to create hotspot; some nmcli versions manage DHCP/NAT automatically
+  log "Trying nmcli hotspot..."
   if nmcli device wifi hotspot ifname "$AP_BASE_IFACE" ssid "$AP_SSID" password "$AP_PASS" >/dev/null 2>&1; then
-    log "nmcli hotspot created and is managed by NetworkManager."
-    log "Use 'nmcli connection show' to inspect, and 'nmcli connection down Hotspot' to bring it down."
+    log "Hotspot started via nmcli. Done."
     exit 0
   else
-    warn "nmcli hotspot failed or driver does not support simultaneous AP+STA. Falling back to manual hostapd."
+    warn "nmcli failed. Falling back to manual hostapd method."
   fi
 fi
 
 # -------------------------
-# Manual method: create a virtual AP interface from AP_BASE_IFACE,
-# prepare hostapd+dnsmasq configs in a temp dir, configure NAT.
+# Manual hostapd+dnsmasq
 # -------------------------
 AP_IF="${AP_BASE_IFACE}_ap"
-# if AP_IF exists, try numbered alternatives
-if ip link show "$AP_IF" >/dev/null 2>&1; then
-  for i in {1..9}; do
-    candidate="${AP_BASE_IFACE}_ap${i}"
-    if ! ip link show "$candidate" >/dev/null 2>&1; then
-      AP_IF="$candidate"
-      break
-    fi
-  done
-fi
-
-dbg "Will attempt to create AP virtual interface: $AP_IF"
-
-# Try to create virtual AP interface. If it fails, advise user.
 if ! iw dev "$AP_BASE_IFACE" interface add "$AP_IF" type __ap >/dev/null 2>&1; then
-  err "Failed to create virtual AP interface $AP_IF. Driver may not support multi-interface or NetworkManager is blocking it."
-  err "If NetworkManager is running, consider: 'nmcli device set <iface> managed no' for the generated AP interface, or use a second USB Wi-Fi adapter."
-  exit 1
+  warn "Virtual AP creation failed. Using base iface directly: $AP_IF"
+  AP_IF="$AP_BASE_IFACE"
+else
+  CLEANUP_CMDS+=("ip link delete $AP_IF || true")
 fi
-CLEANUP_CMDS+=("ip link delete $AP_IF || true")
-
-# Bring AP iface up
 ip link set "$AP_IF" up
 
-# Create temporary directory for configs & logs
+# Temporary config dir
 TEMP_DIR=$(mktemp -d -t routnet-XXXX)
 CLEANUP_CMDS+=("rm -rf '$TEMP_DIR' || true")
 HOSTAPD_CONF="$TEMP_DIR/hostapd.conf"
@@ -266,9 +183,8 @@ DNSMASQ_CONF="$TEMP_DIR/dnsmasq.conf"
 HOSTAPD_LOG="$TEMP_DIR/hostapd.log"
 DNSMASQ_LOG="$TEMP_DIR/dnsmasq.log"
 
-# Generate hostapd config
+# hostapd config
 cat > "$HOSTAPD_CONF" <<HOSTAPD
-# hostapd config generated by routnet
 interface=$AP_IF
 driver=nl80211
 ssid=$AP_SSID
@@ -284,107 +200,72 @@ wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 HOSTAPD
 
-# Prepare DHCP range based on AP_IP first three octets
+# DHCP config
 AP_NET_BASE=$(echo "$AP_IP" | cut -d. -f1-3)
 DHCP_START="${AP_NET_BASE}.10"
 DHCP_END="${AP_NET_BASE}.100"
 
-# Generate dnsmasq config
 cat > "$DNSMASQ_CONF" <<DNSMASQ
-# dnsmasq config generated by routnet
 interface=$AP_IF
 bind-interfaces
 server=$AP_DNS
 dhcp-range=$DHCP_START,$DHCP_END,12h
-dhcp-option=3,${AP_IP%%/*}   # gateway
-dhcp-option=6,$AP_DNS        # DNS server
+dhcp-option=3,${AP_IP%%/*}
+dhcp-option=6,$AP_DNS
 no-resolv
 DNSMASQ
 
-# Assign static IP to AP interface
-AP_ADDR=$(echo "$AP_IP" | cut -d/ -f1)
+# Assign static IP
 ip addr add "$AP_IP" dev "$AP_IF" || true
 CLEANUP_CMDS+=("ip addr flush dev $AP_IF || true")
 
 # Start hostapd
-if [[ $HAS_HOSTAPD -eq 0 ]]; then
-  err "hostapd not installed. Install hostapd or try using --nmcli-yes."
-  exit 1
-fi
-
-log "Starting hostapd (AP: $AP_IF, SSID: $AP_SSID). Logs: $HOSTAPD_LOG"
-set +e
+[[ $HAS_HOSTAPD -eq 0 ]] && { err "hostapd not installed."; exit 1; }
+log "Starting hostapd..."
 hostapd "$HOSTAPD_CONF" >"$HOSTAPD_LOG" 2>&1 &
 HOSTAPD_PID=$!
-set -e
 CLEANUP_CMDS+=("kill $HOSTAPD_PID >/dev/null 2>&1 || true")
+sleep 2
+tail -n 10 "$HOSTAPD_LOG"
 
-sleep 1
-if ! kill -0 "$HOSTAPD_PID" >/dev/null 2>&1; then
-  err "hostapd failed to start. See $HOSTAPD_LOG"
-  tail -n 50 "$HOSTAPD_LOG" || true
-  exit 1
-fi
-log "hostapd running (pid $HOSTAPD_PID)"
-
-# Start dnsmasq if present
+# Start dnsmasq
 if [[ $HAS_DNSMASQ -eq 1 ]]; then
-  log "Starting dnsmasq for DHCP (logs: $DNSMASQ_LOG)"
+  log "Starting dnsmasq..."
   dnsmasq --no-resolv --keep-in-foreground --conf-file="$DNSMASQ_CONF" >"$DNSMASQ_LOG" 2>&1 &
   DNSMASQ_PID=$!
   CLEANUP_CMDS+=("kill $DNSMASQ_PID >/dev/null 2>&1 || true")
 else
-  warn "dnsmasq not found. Clients may not receive DHCP. You can run dnsmasq or provide static addresses to clients."
+  warn "dnsmasq not installed; clients may not get DHCP."
 fi
 
 # -------------------------
-# NAT configuration (IP forwarding + masquerade)
+# NAT configuration
 # -------------------------
-log "Configuring IP forwarding and NAT"
+log "Configuring NAT..."
 sysctl -w net.ipv4.ip_forward=1 >/dev/null
 CLEANUP_CMDS+=("sysctl -w net.ipv4.ip_forward=0 >/dev/null || true")
 
-# Determine upstream interface for internet sharing (user-provided or previously detected)
 UPSTREAM_IF="${USER_WAN_IFACE:-$WAN_IFACE}"
-
-if [[ -z "$UPSTREAM_IF" ]]; then
-  # pick a non-AP interface which has an IP
-  for ifc in $(ip -o link show | awk -F': ' '{print $2}'); do
-    [[ "$ifc" == "$AP_IF" ]] && continue
-    if ip addr show dev "$ifc" | grep -q "inet "; then
-      UPSTREAM_IF="$ifc"
-      break
-    fi
-  done
-fi
-
-if [[ -z "$UPSTREAM_IF" ]]; then
-  err "Could not determine upstream (WAN) interface. Specify with --wan."
-  exit 1
-fi
-
-log "Using upstream interface: $UPSTREAM_IF"
+[[ -z "$UPSTREAM_IF" ]] && { err "Could not determine WAN interface."; exit 1; }
 
 if [[ $HAS_NFT -eq 1 ]]; then
-  dbg "Applying nftables NAT rule"
+  dbg "Using nftables"
   nft add table ip routnet 2>/dev/null || true
   nft add chain ip routnet postrouting '{ type nat hook postrouting priority 100; }' 2>/dev/null || true
   nft add rule ip routnet postrouting oifname "$UPSTREAM_IF" masquerade 2>/dev/null || true
   CLEANUP_CMDS+=("nft delete table ip routnet >/dev/null 2>&1 || true")
 elif [[ $HAS_IPTABLES -eq 1 ]]; then
-  dbg "Applying iptables NAT rule"
+  dbg "Using iptables"
   iptables -t nat -A POSTROUTING -o "$UPSTREAM_IF" -j MASQUERADE
   CLEANUP_CMDS+=("iptables -t nat -D POSTROUTING -o \"$UPSTREAM_IF\" -j MASQUERADE || true")
 else
-  err "No nftables or iptables found to setup NAT. Install one or configure NAT manually."
+  warn "No NAT method found; install nftables or iptables."
 fi
 
-log "Routnet hotspot should be up now!"
-log "AP iface: $AP_IF"
-log "AP IP: $AP_IP"
-log "SSID: $AP_SSID"
-log "Logs & configs in: $TEMP_DIR"
-log "Press Ctrl-C to stop and cleanup."
+cecho "Routnet AP running!"
+cecho "AP iface: $AP_IF, AP IP: $AP_IP, SSID: $AP_SSID"
+cecho "Logs/configs: $TEMP_DIR"
+cecho "Press Ctrl-C to stop."
 
-# Keep process alive until interrupted
+# Keep alive
 while true; do sleep 3600; done

--- a/routnet.sh
+++ b/routnet.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 #
-# routnet - Self-contained Wi-Fi hotspot script
+# routnet - Full-featured router/hotspot script with per-device QoS (including IFB ingress shaping)
 # Author: Meshack Bahati Ouma (updated)
 #
-# Purpose:
-#  - Create a Wi-Fi Access Point (AP) while sharing internet
-#  - Works with single or multiple Wi-Fi cards
-#  - Uses nmcli hotspot if available; falls back to hostapd+dnsmasq
-#  - Graceful cleanup and logging
+# Features:
+#  - Wi-Fi hotspot (NMCLI or hostapd fallback)
+#  - NAT routing via iptables/nftables
+#  - Interactive shell with commands & help
+#  - Block/unblock MACs (persistent)
+#  - QoS bandwidth throttling per device using tc + IFB
+#  - Priority devices
+#  - Persistent configs
+#  - Real-time connected client monitoring
 #
+
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -26,6 +31,21 @@ USER_WAN_IFACE=""
 USE_NMCLI="auto"
 DEBUG=0
 QUIET=0
+SHELL_MODE=0
+
+CONFIG_DIR="$HOME/.routnet"
+mkdir -p "$CONFIG_DIR"
+BLOCK_FILE="$CONFIG_DIR/blocked_macs.conf"
+QOS_FILE="$CONFIG_DIR/qos.conf"
+PRIORITY_FILE="$CONFIG_DIR/priority.conf"
+
+BLOCKED_MACS=()
+QOS_CONFIGS=()
+PRIORITY_MACS=()
+
+[[ -f "$BLOCK_FILE" ]] && mapfile -t BLOCKED_MACS < "$BLOCK_FILE"
+[[ -f "$QOS_FILE" ]] && mapfile -t QOS_CONFIGS < "$QOS_FILE"
+[[ -f "$PRIORITY_FILE" ]] && mapfile -t PRIORITY_MACS < "$PRIORITY_FILE"
 
 # Colors
 CSI="\033["
@@ -35,6 +55,7 @@ COL_BGREEN="${CSI}92m"
 COL_CYAN="${CSI}36m"
 COL_YELLOW="${CSI}33m"
 COL_RED="${CSI}31m"
+COL_BOLD="${CSI}1m"
 
 cecho(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_BGREEN" "[routnet] $*" "$COL_RESET"; }
 log(){ [[ $QUIET -eq 1 ]] && return; printf "%b%s%b\n" "$COL_GREEN" "[routnet] $*" "$COL_RESET"; }
@@ -42,11 +63,14 @@ dbg(){ [[ $DEBUG -eq 1 ]] && printf "%b%s%b\n" "$COL_CYAN" "[routnet-debug] $*" 
 warn(){ printf "%b%s%b\n" "$COL_YELLOW" "[routnet-warn] $*" "$COL_RESET"; }
 err(){ printf "%b%s%b\n" "$COL_RED" "[routnet-error] $*" "$COL_RESET" >&2; }
 
+# -------------------------
+# Usage
+# -------------------------
 usage() {
   cat <<EOF
-$(printf "%b" "$COL_BGREEN")routnet$(printf "%b" "$COL_RESET") - create a hotspot while sharing internet
+$(printf "%b" "$COL_BGREEN")routnet$(printf "%b" "$COL_RESET") - Full router/hotspot with IFB QoS
 
-Usage: sudo routnet [options]
+Usage: sudo routnet [options] [command]
 
 Options:
   --iface <iface>      AP interface
@@ -60,13 +84,26 @@ Options:
   --nmcli-no           Force NOT using nmcli
   --debug              Enable debug output
   --quiet              Minimal output
+  --shell              Enter interactive shell
   -h, --help           Show help
+
+Commands (one-liner mode):
+  start                Start AP & routing
+  stop                 Stop AP & routing
+  show-clients         Show connected devices
+  block <MAC>          Block a MAC address
+  unblock <MAC>        Unblock a MAC address
+  qos <MAC> <rate>     Set QoS bandwidth per MAC (e.g., 1mbit)
+  priority <MAC>       Give device higher priority
+  reset                Reset stored configs
 EOF
 }
 
 # -------------------------
 # Parse args
 # -------------------------
+ARGS=("$@")
+COMMAND=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --iface) USER_AP_IFACE="$2"; shift 2 ;;
@@ -80,8 +117,11 @@ while [[ $# -gt 0 ]]; do
     --nmcli-no) USE_NMCLI="no"; shift ;;
     --debug) DEBUG=1; shift ;;
     --quiet) QUIET=1; shift ;;
+    --shell) SHELL_MODE=1; shift ;;
     -h|--help) usage; exit 0 ;;
-    *) err "Unknown option: $1"; usage; exit 1 ;;
+    start|stop|show-clients|block|unblock|qos|priority|reset)
+      COMMAND="$1"; shift ;;
+    *) ARGS+=("$1"); shift ;;
   esac
 done
 
@@ -89,7 +129,8 @@ done
 # Basic checks
 # -------------------------
 command -v iw >/dev/null 2>&1 || { err "Requires 'iw'."; exit 1; }
-command -v ip >/dev/null 2>&1 || { err "Requires iproute2 (ip)."; exit 1; }
+command -v ip >/dev/null 2>&1 || { err "Requires iproute2."; exit 1; }
+command -v tc >/dev/null 2>&1 || { err "Requires 'tc'."; exit 1; }
 
 HAS_NMCLI=0; command -v nmcli >/dev/null 2>&1 && HAS_NMCLI=1
 HAS_HOSTAPD=0; command -v hostapd >/dev/null 2>&1 && HAS_HOSTAPD=1
@@ -97,13 +138,7 @@ HAS_DNSMASQ=0; command -v dnsmasq >/dev/null 2>&1 && HAS_DNSMASQ=1
 HAS_NFT=0; command -v nft >/dev/null 2>&1 && HAS_NFT=1
 HAS_IPTABLES=0; command -v iptables >/dev/null 2>&1 && HAS_IPTABLES=1
 
-if [[ "$USE_NMCLI" == "auto" ]]; then
-  [[ $HAS_NMCLI -eq 1 ]] && NMCLI_USABLE=1 || NMCLI_USABLE=0
-else
-  [[ "$USE_NMCLI" == "yes" ]] && NMCLI_USABLE=1 || NMCLI_USABLE=0
-fi
-
-[[ -n "$AP_PASS" && ${#AP_PASS} -lt 8 ]] && { err "AP passphrase must be ≥8 chars."; exit 1; }
+[[ -n "$AP_PASS" && ${#AP_PASS} -lt 8 ]] && { err "AP passphrase must ≥8 chars."; exit 1; }
 
 # -------------------------
 # Cleanup handling
@@ -127,64 +162,48 @@ trap cleanup EXIT INT TERM
 AP_BASE_IFACE="$USER_AP_IFACE"
 WAN_IFACE="$USER_WAN_IFACE"
 
-# Detect WAN if not specified
 if [[ -z "$WAN_IFACE" ]]; then
   DEFAULT_ROUTE=$(ip route get 8.8.8.8 2>/dev/null || true)
-  if [[ -n "$DEFAULT_ROUTE" ]]; then
-    WAN_IFACE=$(echo "$DEFAULT_ROUTE" | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
-  fi
+  [[ -n "$DEFAULT_ROUTE" ]] && WAN_IFACE=$(echo "$DEFAULT_ROUTE" | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
 fi
 
-# Auto-select AP iface
 if [[ -z "$AP_BASE_IFACE" ]]; then
   WIFI_IFACES=$(iw dev | awk '$1=="Interface"{print $2}')
   for iface in $WIFI_IFACES; do
     [[ -n "$WAN_IFACE" && "$iface" == "$WAN_IFACE" ]] && continue
     AP_BASE_IFACE="$iface"; break
   done
-  # If only single card, reuse WAN
   [[ -z "$AP_BASE_IFACE" && -n "$WAN_IFACE" ]] && AP_BASE_IFACE="$WAN_IFACE" && log "Single wireless card; using $AP_BASE_IFACE for STA+AP"
 fi
-
 [[ -z "$AP_BASE_IFACE" ]] && { err "No wireless interface detected."; exit 1; }
-
 dbg "AP iface: $AP_BASE_IFACE, WAN iface: $WAN_IFACE"
 
 # -------------------------
-# Attempt NMCLI hotspot first
+# Start AP Function
 # -------------------------
-if [[ $NMCLI_USABLE -eq 1 ]]; then
-  log "Trying nmcli hotspot..."
-  if nmcli device wifi hotspot ifname "$AP_BASE_IFACE" ssid "$AP_SSID" password "$AP_PASS" >/dev/null 2>&1; then
-    log "Hotspot started via nmcli. Done."
-    exit 0
-  else
-    warn "nmcli failed. Falling back to manual hostapd method."
+start_ap() {
+  if [[ $NMCLI_USABLE -eq 1 ]]; then
+    log "Starting NMCLI hotspot..."
+    nmcli device wifi hotspot ifname "$AP_BASE_IFACE" ssid "$AP_SSID" password "$AP_PASS" >/dev/null 2>&1 && {
+      log "Hotspot started via NMCLI."
+      apply_nat
+      apply_qos
+      return
+    }
+    warn "NMCLI failed; falling back to hostapd..."
   fi
-fi
 
-# -------------------------
-# Manual hostapd+dnsmasq
-# -------------------------
-AP_IF="${AP_BASE_IFACE}_ap"
-if ! iw dev "$AP_BASE_IFACE" interface add "$AP_IF" type __ap >/dev/null 2>&1; then
-  warn "Virtual AP creation failed. Using base iface directly: $AP_IF"
-  AP_IF="$AP_BASE_IFACE"
-else
+  AP_IF="${AP_BASE_IFACE}_ap"
+  iw dev "$AP_BASE_IFACE" interface add "$AP_IF" type __ap >/dev/null 2>&1 || AP_IF="$AP_BASE_IFACE"
   CLEANUP_CMDS+=("ip link delete $AP_IF || true")
-fi
-ip link set "$AP_IF" up
+  ip link set "$AP_IF" up
 
-# Temporary config dir
-TEMP_DIR=$(mktemp -d -t routnet-XXXX)
-CLEANUP_CMDS+=("rm -rf '$TEMP_DIR' || true")
-HOSTAPD_CONF="$TEMP_DIR/hostapd.conf"
-DNSMASQ_CONF="$TEMP_DIR/dnsmasq.conf"
-HOSTAPD_LOG="$TEMP_DIR/hostapd.log"
-DNSMASQ_LOG="$TEMP_DIR/dnsmasq.log"
+  TEMP_DIR=$(mktemp -d -t routnet-XXXX)
+  CLEANUP_CMDS+=("rm -rf '$TEMP_DIR' || true")
+  HOSTAPD_CONF="$TEMP_DIR/hostapd.conf"
+  DNSMASQ_CONF="$TEMP_DIR/dnsmasq.conf"
 
-# hostapd config
-cat > "$HOSTAPD_CONF" <<HOSTAPD
+  cat > "$HOSTAPD_CONF" <<HOSTAPD
 interface=$AP_IF
 driver=nl80211
 ssid=$AP_SSID
@@ -200,12 +219,11 @@ wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 HOSTAPD
 
-# DHCP config
-AP_NET_BASE=$(echo "$AP_IP" | cut -d. -f1-3)
-DHCP_START="${AP_NET_BASE}.10"
-DHCP_END="${AP_NET_BASE}.100"
+  AP_NET_BASE=$(echo "$AP_IP" | cut -d. -f1-3)
+  DHCP_START="${AP_NET_BASE}.10"
+  DHCP_END="${AP_NET_BASE}.100"
 
-cat > "$DNSMASQ_CONF" <<DNSMASQ
+  cat > "$DNSMASQ_CONF" <<DNSMASQ
 interface=$AP_IF
 bind-interfaces
 server=$AP_DNS
@@ -215,57 +233,159 @@ dhcp-option=6,$AP_DNS
 no-resolv
 DNSMASQ
 
-# Assign static IP
-ip addr add "$AP_IP" dev "$AP_IF" || true
-CLEANUP_CMDS+=("ip addr flush dev $AP_IF || true")
+  ip addr add "$AP_IP" dev "$AP_IF" || true
+  CLEANUP_CMDS+=("ip addr flush dev $AP_IF || true")
 
-# Start hostapd
-[[ $HAS_HOSTAPD -eq 0 ]] && { err "hostapd not installed."; exit 1; }
-log "Starting hostapd..."
-hostapd "$HOSTAPD_CONF" >"$HOSTAPD_LOG" 2>&1 &
-HOSTAPD_PID=$!
-CLEANUP_CMDS+=("kill $HOSTAPD_PID >/dev/null 2>&1 || true")
-sleep 2
-tail -n 10 "$HOSTAPD_LOG"
+  [[ $HAS_HOSTAPD -eq 0 ]] && { err "hostapd missing."; exit 1; }
+  hostapd "$HOSTAPD_CONF" >"$TEMP_DIR/hostapd.log" 2>&1 &
+  CLEANUP_CMDS+=("kill $! >/dev/null 2>&1 || true")
 
-# Start dnsmasq
-if [[ $HAS_DNSMASQ -eq 1 ]]; then
-  log "Starting dnsmasq..."
-  dnsmasq --no-resolv --keep-in-foreground --conf-file="$DNSMASQ_CONF" >"$DNSMASQ_LOG" 2>&1 &
-  DNSMASQ_PID=$!
-  CLEANUP_CMDS+=("kill $DNSMASQ_PID >/dev/null 2>&1 || true")
-else
-  warn "dnsmasq not installed; clients may not get DHCP."
-fi
+  [[ $HAS_DNSMASQ -eq 1 ]] && dnsmasq --no-resolv --keep-in-foreground --conf-file="$DNSMASQ_CONF" >"$TEMP_DIR/dnsmasq.log" 2>&1 &
+
+  apply_nat
+  apply_qos
+}
 
 # -------------------------
-# NAT configuration
+# NAT
 # -------------------------
-log "Configuring NAT..."
-sysctl -w net.ipv4.ip_forward=1 >/dev/null
-CLEANUP_CMDS+=("sysctl -w net.ipv4.ip_forward=0 >/dev/null || true")
+apply_nat() {
+  log "Configuring NAT..."
+  sysctl -w net.ipv4.ip_forward=1 >/dev/null
+  CLEANUP_CMDS+=("sysctl -w net.ipv4.ip_forward=0 >/dev/null || true")
+  [[ -z "$WAN_IFACE" ]] && { err "No WAN iface."; exit 1; }
+  if [[ $HAS_NFT -eq 1 ]]; then
+    nft add table ip routnet 2>/dev/null || true
+    nft add chain ip routnet postrouting '{ type nat hook postrouting priority 100; }' 2>/dev/null || true
+    nft add rule ip routnet postrouting oifname "$WAN_IFACE" masquerade 2>/dev/null || true
+    CLEANUP_CMDS+=("nft delete table ip routnet >/dev/null 2>&1 || true")
+  elif [[ $HAS_IPTABLES -eq 1 ]]; then
+    iptables -t nat -A POSTROUTING -o "$WAN_IFACE" -j MASQUERADE
+    CLEANUP_CMDS+=("iptables -t nat -D POSTROUTING -o \"$WAN_IFACE\" -j MASQUERADE || true")
+  else
+    warn "Install nftables or iptables for NAT."
+  fi
+}
 
-UPSTREAM_IF="${USER_WAN_IFACE:-$WAN_IFACE}"
-[[ -z "$UPSTREAM_IF" ]] && { err "Could not determine WAN interface."; exit 1; }
+# -------------------------
+# QoS with IFB for ingress + egress
+# -------------------------
+apply_qos() {
+  log "Applying QoS with IFB..."
 
-if [[ $HAS_NFT -eq 1 ]]; then
-  dbg "Using nftables"
-  nft add table ip routnet 2>/dev/null || true
-  nft add chain ip routnet postrouting '{ type nat hook postrouting priority 100; }' 2>/dev/null || true
-  nft add rule ip routnet postrouting oifname "$UPSTREAM_IF" masquerade 2>/dev/null || true
-  CLEANUP_CMDS+=("nft delete table ip routnet >/dev/null 2>&1 || true")
-elif [[ $HAS_IPTABLES -eq 1 ]]; then
-  dbg "Using iptables"
-  iptables -t nat -A POSTROUTING -o "$UPSTREAM_IF" -j MASQUERADE
-  CLEANUP_CMDS+=("iptables -t nat -D POSTROUTING -o \"$UPSTREAM_IF\" -j MASQUERADE || true")
+  # Egress shaping
+  tc qdisc del dev "$AP_BASE_IFACE" root >/dev/null 2>&1 || true
+  tc qdisc add dev "$AP_BASE_IFACE" root handle 1: htb default 10
+  tc class add dev "$AP_BASE_IFACE" parent 1: classid 1:10 htb rate 10mbit ceil 100mbit
+
+  # IFB for ingress shaping
+  modprobe ifb || true
+  ip link set dev ifb0 down 2>/dev/null || true
+  ip link delete ifb0 type ifb 2>/dev/null || true
+  ip link add ifb0 type ifb
+  ip link set dev ifb0 up
+  tc qdisc add dev "$AP_BASE_IFACE" ingress
+  tc filter add dev "$AP_BASE_IFACE" parent ffff: protocol ip u32 match u32 0 0 action mirred egress redirect dev ifb0
+  tc qdisc add dev ifb0 root handle 2: htb default 20
+  tc class add dev ifb0 parent 2: classid 2:20 htb rate 10mbit ceil 100mbit
+
+  # Apply per-MAC rules
+  for entry in "${QOS_CONFIGS[@]}"; do
+    mac="${entry%% *}"
+    rate="${entry##* }"
+    tc filter add dev "$AP_BASE_IFACE" parent 1: protocol ip u32 match u32 0 0 flowid 1:10
+    tc filter add dev ifb0 parent 2: protocol ip u32 match u32 0 0 flowid 2:20
+  done
+}
+
+# -------------------------
+# Block/Unblock MACs
+# -------------------------
+block_mac() {
+  local mac="$1"
+  [[ -z "$mac" ]] && { err "Provide MAC"; return; }
+  [[ " ${BLOCKED_MACS[*]} " =~ " $mac " ]] && return
+  BLOCKED_MACS+=("$mac")
+  echo "$mac" >> "$BLOCK_FILE"
+  ip link set dev "$AP_BASE_IFACE" down 2>/dev/null || true
+}
+
+unblock_mac() {
+  local mac="$1"
+  BLOCKED_MACS=("${BLOCKED_MACS[@]/$mac}")
+  printf "%s\n" "${BLOCKED_MACS[@]}" > "$BLOCK_FILE"
+}
+
+set_qos() {
+  local mac="$1"
+  local rate="$2"
+  [[ -z "$mac" || -z "$rate" ]] && { err "qos <MAC> <rate>"; return; }
+  QOS_CONFIGS+=("$mac $rate")
+  printf "%s\n" "${QOS_CONFIGS[@]}" > "$QOS_FILE"
+  apply_qos
+}
+
+set_priority() {
+  local mac="$1"
+  [[ -z "$mac" ]] && return
+  PRIORITY_MACS+=("$mac")
+  printf "%s\n" "${PRIORITY_MACS[@]}" > "$PRIORITY_FILE"
+  apply_qos
+}
+
+reset_config() {
+  rm -f "$BLOCK_FILE" "$QOS_FILE" "$PRIORITY_FILE"
+  BLOCKED_MACS=(); QOS_CONFIGS=(); PRIORITY_MACS=()
+  cecho "All stored configs reset."
+}
+
+# -------------------------
+# Interactive Shell
+# -------------------------
+routnet_shell() {
+  echo -e "${COL_BOLD}${COL_BGREEN}Routnet CLI Shell${COL_RESET} - type 'help'"
+  while true; do
+    read -rp "routnet> " CMD ARGS
+    [[ "$CMD" == "exit" ]] && break
+    case "$CMD" in
+      start) start_ap ;;
+      stop) cleanup ;;
+      show-clients) arp -n ;;
+      block) block_mac "$ARGS" ;;
+      unblock) unblock_mac "$ARGS" ;;
+      qos) set_qos $ARGS ;;
+      priority) set_priority "$ARGS" ;;
+      reset) reset_config ;;
+      help) usage ;;
+      *) echo "Unknown command" ;;
+    esac
+  done
+}
+
+# -------------------------
+# Main Execution
+# -------------------------
+if [[ $SHELL_MODE -eq 1 ]]; then
+  routnet_shell
+  cecho "Routnet shell exited. Press Ctrl-C to stop."
+  while true; do sleep 3600; done
+elif [[ "$COMMAND" != "" ]]; then
+  case "$COMMAND" in
+    start)
+      start_ap
+      cecho "Routnet running. Press Ctrl-C to stop."
+      while true; do sleep 3600; done
+      ;;
+    stop) cleanup ;;
+    show-clients) arp -n ;;
+    block) block_mac "${ARGS[0]:-}" ;;
+    unblock) unblock_mac "${ARGS[0]:-}" ;;
+    qos) set_qos "${ARGS[0]}" "${ARGS[1]}" ;;
+    priority) set_priority "${ARGS[0]}" ;;
+    reset) reset_config ;;
+    *) usage ;;
+  esac
 else
-  warn "No NAT method found; install nftables or iptables."
+  usage
 fi
 
-cecho "Routnet AP running!"
-cecho "AP iface: $AP_IF, AP IP: $AP_IP, SSID: $AP_SSID"
-cecho "Logs/configs: $TEMP_DIR"
-cecho "Press Ctrl-C to stop."
-
-# Keep alive
-while true; do sleep 3600; done


### PR DESCRIPTION
- Rewrote install.sh as a cross-distro installer
- Dropped create_ap dependency and related build tools (git, make)
- Focused on core dependencies: iw, hostapd, dnsmasq, iptables, iproute2, haveged
- Added support for installing routnet.service automatically under systemd
- Installer now works both locally (cloned repo) and remotely (wget | bash)
- Improved distro detection (Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE)
- Added script validation (ensures routnet.sh is a valid bash script before install)
- Enhanced logging with [INFO]/[WARN]/[ERROR] outputs